### PR TITLE
Stream backup archives directly from blob storage

### DIFF
--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/DownloadController.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/DownloadController.java
@@ -47,12 +47,24 @@ public class DownloadController {
         String key = tokenInfo.getKey();
         String type = tokenInfo.getType();
 
+        if ("archive".equals(type)) {
+            BackupService.BackupStreamInfo streamInfo = backupService
+                    .streamBackup(databaseConfiguration.getPrefix(), key);
+            InputStreamResource resource = new InputStreamResource(
+                    streamInfo.inputStream());
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_DISPOSITION,
+                            "attachment; filename=\"" + key + "\"")
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                    .contentLength(streamInfo.contentLength())
+                    .body(resource);
+        }
+
         File backupZipFile = backupService
                 .downloadBackup(databaseConfiguration.getPrefix(), key);
 
         return switch (type) {
-            case "archive" -> streamFile(backupZipFile, key,
-                    MediaType.APPLICATION_OCTET_STREAM);
             case "pgdump" -> {
                 File pgdumpFile = zipService.extractPgdumpFile(backupZipFile);
                 backupZipFile.delete();

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/BackupService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/BackupService.java
@@ -2,6 +2,7 @@ package io.github.mucsi96.postgresbackuptool.service;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -18,7 +19,9 @@ import org.springframework.core.io.WritableResource;
 import org.springframework.stereotype.Service;
 
 import com.azure.spring.cloud.core.resource.AzureStorageBlobProtocolResolver;
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobProperties;
 
 import io.github.mucsi96.postgresbackuptool.model.Backup;
 import lombok.extern.slf4j.Slf4j;
@@ -91,6 +94,16 @@ public class BackupService {
         try (OutputStream os = resource.getOutputStream()) {
             Files.copy(dumpFile.toPath(), os);
         }
+    }
+
+    public record BackupStreamInfo(InputStream inputStream, long contentLength) {}
+
+    public BackupStreamInfo streamBackup(String prefix, String key) {
+        BlobClient blobClient = blobContainerClient
+                .getBlobClient(prefix + "/" + key);
+        BlobProperties properties = blobClient.getProperties();
+        InputStream inputStream = blobClient.openInputStream();
+        return new BackupStreamInfo(inputStream, properties.getBlobSize());
     }
 
     public File downloadBackup(String prefix, String key) throws IOException {


### PR DESCRIPTION
## Summary
Refactored the backup download flow to stream archive files directly from Azure Blob Storage instead of downloading them to disk first. This improves performance and reduces disk I/O for archive downloads.

## Key Changes
- Added `BackupStreamInfo` record to encapsulate streaming metadata (input stream and content length)
- Introduced `streamBackup()` method in `BackupService` that opens a direct input stream from blob storage and retrieves blob properties
- Modified `DownloadController` to handle archive downloads via streaming before attempting disk-based download
- Removed the disk-based archive download path from the switch statement, as archives now use the streaming approach

## Implementation Details
- The streaming approach retrieves `BlobProperties` to obtain the accurate content length for the HTTP response
- Archive downloads now bypass the intermediate file download step (`downloadBackup()`), reducing temporary disk usage
- The controller sets appropriate HTTP headers (`Content-Disposition`, `Content-Type`, `Content-Length`) for the streamed response
- Non-archive backup types (pgdump, etc.) continue to use the existing disk-based download flow

https://claude.ai/code/session_019R97GinPucKrRFPQdiPC6w