### PR TITLE
Migrate MSAL authentication from popup to redirect flow

### DIFF
--- a/client/src/app/auth.service.ts
+++ b/client/src/app/auth.service.ts
@@ -2,8 +2,6 @@ import { inject, Injectable, signal } from '@angular/core';
 import { MsalBroadcastService, MsalService } from '@azure/msal-angular';
 import {
   AuthenticationResult,
-  EventMessage,
-  EventType,
   InteractionStatus,
 } from '@azure/msal-browser';
 import { filter } from 'rxjs';
@@ -23,15 +21,13 @@ export class AuthService {
     : undefined;
 
   constructor() {
-    this.msalBroadcastService?.msalSubject$
-      .pipe(
-        filter((msg: EventMessage) => msg.eventType === EventType.LOGIN_SUCCESS)
-      )
-      .subscribe((result: EventMessage) => {
-        console.log(result);
-        const payload = result.payload as AuthenticationResult;
-        this.msalService?.instance.setActiveAccount(payload.account);
-      });
+    this.msalService?.handleRedirectObservable().subscribe({
+      next: (result: AuthenticationResult | null) => {
+        if (result) {
+          this.msalService?.instance.setActiveAccount(result.account);
+        }
+      },
+    });
 
     this.msalBroadcastService?.inProgress$
       .pipe(

--- a/client/src/app/msal.config.ts
+++ b/client/src/app/msal.config.ts
@@ -28,6 +28,7 @@ export function MSALInstanceFactory(config: EnvironmentConfig): IPublicClientApp
     auth: {
       clientId: config.clientId,
       authority: `https://login.microsoftonline.com/${config.tenantId}`,
+      redirectUri: '/',
     },
     cache: {
       cacheLocation: BrowserCacheLocation.SessionStorage,
@@ -62,7 +63,7 @@ export function MSALInterceptorConfigFactory(config: EnvironmentConfig): MsalInt
   );
 
   return {
-    interactionType: InteractionType.Popup,
+    interactionType: InteractionType.Redirect,
     protectedResourceMap,
   };
 }
@@ -77,7 +78,7 @@ export function MSALGuardConfigFactory(config: EnvironmentConfig): MsalGuardConf
   ].map((scope) => `${config.apiClientId}/${scope}`);
 
   return {
-    interactionType: InteractionType.Popup,
+    interactionType: InteractionType.Redirect,
     authRequest: {
       scopes: ['user.read', ...apiScopes],
     },

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2,19 +2,12 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { getAppConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 import { EnvironmentConfig } from './app/environment/environment.config';
-import { BrowserUtils } from '@azure/msal-browser';
 import '@mucsi96/ui-elements';
 
-if (BrowserUtils.isInPopup() || BrowserUtils.isInIframe()) {
-  import('@azure/msal-browser/redirect-bridge').then(({ broadcastResponseToMainFrame }) =>
-    broadcastResponseToMainFrame().catch((err) => console.error(err))
-  );
-} else {
-  loadEnvironmentConfig().then(environment => {
-    bootstrapApplication(AppComponent, getAppConfig(environment))
-      .catch((err) => console.error(err));
-  });
-}
+loadEnvironmentConfig().then(environment => {
+  bootstrapApplication(AppComponent, getAppConfig(environment))
+    .catch((err) => console.error(err));
+});
 
 async function loadEnvironmentConfig(): Promise<EnvironmentConfig> {
   const response = await fetch('/api/environment');


### PR DESCRIPTION
## Summary
This PR migrates the Azure MSAL authentication implementation from popup-based interactions to redirect-based flow. This includes updating the authentication service to use the redirect observable, removing popup-specific code, and configuring the MSAL instance with redirect-based interaction types.

## Key Changes
- **Auth Service**: Replaced event message filtering with `handleRedirectObservable()` for cleaner redirect flow handling
- **MSAL Configuration**: Changed interaction type from `Popup` to `Redirect` for both interceptor and guard configurations
- **Redirect URI**: Added explicit `redirectUri: '/'` configuration to the MSAL auth settings
- **Bootstrap Logic**: Removed popup/iframe detection and redirect bridge logic from main.ts, simplifying the application startup
- **Cleanup**: Removed unused imports (`EventMessage`, `EventType`, `BrowserUtils`)

## Implementation Details
The authentication flow now uses MSAL's `handleRedirectObservable()` which automatically handles the redirect response after login. The redirect-based approach is more suitable for single-page applications and eliminates the complexity of managing popup windows. The application bootstrap process is now straightforward without conditional popup/iframe handling.

https://claude.ai/code/session_01S7YCf7cAX4ojwYtLqPnXgE