### PR TITLE
Add backup creation functionality from tables view

### DIFF
--- a/client/src/app/tables/tables.component.html
+++ b/client/src/app/tables/tables.component.html
@@ -1,6 +1,7 @@
 @if (tableData.isLoading()) {
 <div role="progressbar" bt></div>
 } @else {
+<button bt [disabled]="processing()" (click)="createBackup()">Backup</button>
 <h2 bt>
   Records <span bt-badge>{{ totalRowCount() }}</span>
 </h2>

--- a/client/src/app/tables/tables.component.ts
+++ b/client/src/app/tables/tables.component.ts
@@ -1,4 +1,5 @@
 import { Component, computed, inject } from '@angular/core';
+import { BackupsService } from '../backups/backups.service';
 import { TablesService } from './tables.service';
 
 @Component({
@@ -9,6 +10,7 @@ import { TablesService } from './tables.service';
 })
 export class TablesComponent {
   private readonly tabeService = inject(TablesService);
+  private readonly backupsService = inject(BackupsService);
   readonly tableData = this.tabeService.tables;
   tables = computed(() => this.tableData.value()?.tables);
   totalRowCount = computed(
@@ -18,4 +20,12 @@ export class TablesComponent {
     () => this.tableData.value()?.fileCount
   );
   processing = this.tabeService.processing;
+
+  async createBackup() {
+    if (this.processing()) {
+      return;
+    }
+    await this.tabeService.createBackup();
+    this.backupsService.backups.reload();
+  }
 }

--- a/client/src/app/tables/tables.service.ts
+++ b/client/src/app/tables/tables.service.ts
@@ -44,6 +44,26 @@ export class TablesService {
     },
   });
 
+  async createBackup() {
+    const databaseName = this.selectedDatabaseService.databaseName();
+    if (!databaseName) {
+      return;
+    }
+    try {
+      this.processing.set(true);
+      await fetchJson<void>(
+        this.http,
+        `/api/database/${databaseName}/backup`,
+        { method: 'post' }
+      );
+      document.dispatchEvent(new SuccessNotificationEvent('Backup created'));
+    } catch (error) {
+      dispatchEvent(new ErrorNotificationEvent('Could not create backup.'));
+    }
+    this.processing.set(false);
+    this.tables.reload();
+  }
+
   async restoreBackup(selectedBackup: string) {
     const databaseName = this.selectedDatabaseService.databaseName();
     if (!databaseName) {

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/BackupController.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/BackupController.java
@@ -52,7 +52,7 @@ public class BackupController {
             throws IOException, InterruptedException {
         DatabaseConfiguration databaseConfiguration = databaseService
                 .getDatabaseConfiguration(databaseName);
-        backupOrchestrationService.performBackupForDatabase(databaseConfiguration, 356);
+        backupOrchestrationService.performBackupForDatabase(databaseConfiguration, 7);
     }
 
     @PreAuthorize("hasAuthority('APPROLE_DatabaseBackupsReader') and hasAuthority('SCOPE_readBackups')")

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/BackupController.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/BackupController.java
@@ -45,6 +45,16 @@ public class BackupController {
         return smartBackupService.performSmartBackup();
     }
 
+    @PreAuthorize("hasAuthority('APPROLE_DatabaseBackupCreator')")
+    @PostMapping("/database/{database_name}/backup")
+    @ResponseBody
+    void performBackup(@PathVariable("database_name") String databaseName)
+            throws IOException, InterruptedException {
+        DatabaseConfiguration databaseConfiguration = databaseService
+                .getDatabaseConfiguration(databaseName);
+        backupOrchestrationService.performBackupForDatabase(databaseConfiguration, 356);
+    }
+
     @PreAuthorize("hasAuthority('APPROLE_DatabaseBackupsReader') and hasAuthority('SCOPE_readBackups')")
     @GetMapping("/database/{database_name}/backups")
     @ResponseBody

--- a/test/tests/test_database.spec.ts
+++ b/test/tests/test_database.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures';
-import { extractTableData, cleanupDb, getDb1Tables, triggerBackup, populateDb, writeFileToFolder } from '../utils';
+import { extractTableData, cleanupDb, getDb1Tables, triggerBackup, populateDb, writeFileToFolder, getBackupsFromStorage } from '../utils';
 
 const TEST_FOLDER_1 = '/tmp/test-uploads';
 const TEST_FOLDER_2 = '/tmp/test-documents';
@@ -95,6 +95,21 @@ test.describe('Database Tests', () => {
     await expect(page.getByRole('heading', { name: 'Records' })).toHaveText('Records 9');
     await expect(page.getByRole('heading', { name: 'Files' })).toHaveText('Files 0');
     await expect(page.getByRole('heading', { name: 'Tables' })).toHaveText('Tables 2');
+  });
+
+  test('creates backup using backup button', async ({ page }) => {
+    await populateDb();
+
+    await page.goto('http://localhost:8280');
+    await page.getByText('db1').click();
+    await expect(page.getByRole('heading', { name: 'Records' })).toHaveText('Records 9');
+
+    await page.getByRole('button', { name: 'Backup' }).click();
+    await expect(page.getByRole('status').filter({ hasText: 'Backup created' })).toBeVisible();
+
+    const backups = await getBackupsFromStorage('db1');
+    expect(backups.length).toBe(1);
+    expect(backups[0].rowsCount).toBe(9);
   });
 
   test('doesnt restore excluded tables', async ({ page }) => {


### PR DESCRIPTION
## Summary
This PR adds the ability to create database backups directly from the tables view by introducing a new "Backup" button in the UI and implementing the corresponding backend endpoint.

## Key Changes
- **Backend**: Added new POST endpoint `/api/database/{database_name}/backup` in `BackupController` that triggers backup creation for a specified database with authorization checks
- **Frontend Service**: Implemented `createBackup()` method in `TablesService` that calls the new backup endpoint, handles errors with notifications, and reloads the tables list
- **Frontend Component**: 
  - Added "Backup" button to the tables component template that triggers backup creation
  - Implemented `createBackup()` method in `TablesComponent` that prevents concurrent operations and refreshes the backups list after creation
  - Injected `BackupsService` to reload backups after successful backup creation
- **Tests**: Added end-to-end test that verifies backup creation via the UI button, confirms success notification appears, and validates the backup was created with correct row count

## Implementation Details
- The backup button is disabled during processing to prevent duplicate requests
- User feedback is provided through success/error notification events
- The backups list is automatically refreshed after backup creation to reflect the new backup
- Authorization is enforced via `@PreAuthorize` annotation requiring `APPROLE_DatabaseBackupCreator` role

https://claude.ai/code/session_01M27YxDzPb4QGVebEvDRMNr