### PR TITLE
Add SQL data export functionality

### DIFF
--- a/client/src/app/tables/tables.component.html
+++ b/client/src/app/tables/tables.component.html
@@ -2,6 +2,7 @@
 <div role="progressbar" bt></div>
 } @else {
 <button bt [disabled]="processing()" (click)="createBackup()">Backup</button>
+<button bt [disabled]="processing()" (click)="exportSql()">Export SQL</button>
 <h2 bt>
   Records <span bt-badge>{{ totalRowCount() }}</span>
 </h2>

--- a/client/src/app/tables/tables.component.ts
+++ b/client/src/app/tables/tables.component.ts
@@ -28,4 +28,11 @@ export class TablesComponent {
     await this.tabeService.createBackup();
     this.backupsService.backups.reload();
   }
+
+  async exportSql() {
+    if (this.processing()) {
+      return;
+    }
+    await this.tabeService.exportSql();
+  }
 }

--- a/client/src/app/tables/tables.service.ts
+++ b/client/src/app/tables/tables.service.ts
@@ -91,6 +91,7 @@ export class TablesService {
       return;
     }
     try {
+      this.processing.set(true);
       const { token } = await fetchJson<{ token: string }>(
         this.http,
         `/api/database/${databaseName}/export-sql/download-token`,
@@ -103,6 +104,7 @@ export class TablesService {
         new ErrorNotificationEvent('Could not export SQL data.')
       );
     }
+    this.processing.set(false);
   }
 
   async downloadBackup(

--- a/client/src/app/tables/tables.service.ts
+++ b/client/src/app/tables/tables.service.ts
@@ -85,6 +85,26 @@ export class TablesService {
     this.tables.reload();
   }
 
+  async exportSql() {
+    const databaseName = this.selectedDatabaseService.databaseName();
+    if (!databaseName) {
+      return;
+    }
+    try {
+      const { token } = await fetchJson<{ token: string }>(
+        this.http,
+        `/api/database/${databaseName}/export-sql/download-token`,
+        { method: 'post' }
+      );
+
+      window.open(`/api/download/${token}`, '_self');
+    } catch (error) {
+      dispatchEvent(
+        new ErrorNotificationEvent('Could not export SQL data.')
+      );
+    }
+  }
+
   async downloadBackup(
     selectedBackup: string,
     type: 'plain' | 'archive' | 'pgdump'

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/BackupController.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/BackupController.java
@@ -101,4 +101,16 @@ public class BackupController {
         String token = downloadTokenService.createToken(databaseName, key, type);
         return Map.of("token", token);
     }
+
+    @PreAuthorize("hasAuthority('APPROLE_DatabaseBackupDownloader') and hasAuthority('SCOPE_downloadBackup')")
+    @PostMapping("/database/{database_name}/export-sql/download-token")
+    @ResponseBody
+    Map<String, String> createExportSqlDownloadToken(
+            @PathVariable("database_name") String databaseName) {
+        // Validate database exists
+        databaseService.getDatabaseConfiguration(databaseName);
+
+        String token = downloadTokenService.createToken(databaseName, "", "data-export");
+        return Map.of("token", token);
+    }
 }

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/DownloadController.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/DownloadController.java
@@ -47,8 +47,14 @@ public class DownloadController {
         if ("data-export".equals(type)) {
             File sqlFile = databaseService
                     .createDataOnlyDump(tokenInfo.getDatabaseName());
-            String filename = tokenInfo.getDatabaseName() + "-data-export.sql";
-            return streamFile(sqlFile, filename, MediaType.TEXT_PLAIN);
+            try {
+                return streamFile(sqlFile,
+                        tokenInfo.getDatabaseName() + "-data-export.sql",
+                        MediaType.TEXT_PLAIN);
+            } catch (IOException e) {
+                sqlFile.delete();
+                throw e;
+            }
         }
 
         DatabaseConfiguration databaseConfiguration = databaseService

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/DownloadController.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/controller/DownloadController.java
@@ -41,11 +41,18 @@ public class DownloadController {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.GONE,
                         "Download link has expired or is invalid"));
 
-        DatabaseConfiguration databaseConfiguration = databaseService
-                .getDatabaseConfiguration(tokenInfo.getDatabaseName());
-
         String key = tokenInfo.getKey();
         String type = tokenInfo.getType();
+
+        if ("data-export".equals(type)) {
+            File sqlFile = databaseService
+                    .createDataOnlyDump(tokenInfo.getDatabaseName());
+            String filename = tokenInfo.getDatabaseName() + "-data-export.sql";
+            return streamFile(sqlFile, filename, MediaType.TEXT_PLAIN);
+        }
+
+        DatabaseConfiguration databaseConfiguration = databaseService
+                .getDatabaseConfiguration(tokenInfo.getDatabaseName());
 
         if ("archive".equals(type)) {
             BackupService.BackupStreamInfo streamInfo = backupService

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/BackupOrchestrationService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/BackupOrchestrationService.java
@@ -115,17 +115,13 @@ public class BackupOrchestrationService {
             logger.info("Creating pgdump (custom format) for: {}", databaseConfiguration.getName());
             dumpFile = databaseService.createDump(
                     databaseConfiguration.getName(),
-                    retentionPeriod,
-                    "custom",
-                    timeString);
+                    "custom");
 
             // Always create plain SQL dump
             logger.info("Creating SQL dump (plain format) for: {}", databaseConfiguration.getName());
             plainDumpFile = databaseService.createDump(
                     databaseConfiguration.getName(),
-                    retentionPeriod,
-                    "plain",
-                    timeString);
+                    "plain");
 
             // Collect folder files from local file system
             logger.info("Collecting files for backup from {} folders",

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
@@ -69,14 +69,34 @@ public class DatabaseService {
     public File createDump(String databaseName, int retentionPeriod,
             String format, String timeString)
             throws IOException, InterruptedException {
+        return executePgDump(databaseName, format, false);
+    }
+
+    public File createDataOnlyDump(String databaseName)
+            throws IOException, InterruptedException {
+        return executePgDump(databaseName, "plain", true);
+    }
+
+    private File executePgDump(String databaseName, String format,
+            boolean dataOnly) throws IOException, InterruptedException {
         DatabaseConfiguration databaseConfiguration = getDatabaseConfiguration(
                 databaseName);
         String suffix = "plain".equals(format) ? ".sql" : ".pgdump";
         File outputFile = File.createTempFile("pgdump-", suffix);
-        List<String> commands = Stream.of(List.of("pg_dump", "--dbname",
-                databaseConfiguration.getConnectionString(), "--schema",
-                databaseConfiguration.getSchema(), "--format", format, "--file",
-                outputFile.getAbsolutePath(), "plain".equals(format) ? "--column-inserts" : ""),
+
+        List<String> baseArgs = new java.util.ArrayList<>(List.of("pg_dump",
+                "--dbname", databaseConfiguration.getConnectionString(),
+                "--schema", databaseConfiguration.getSchema(), "--format",
+                format, "--file", outputFile.getAbsolutePath()));
+
+        if ("plain".equals(format)) {
+            baseArgs.add("--column-inserts");
+        }
+        if (dataOnly) {
+            baseArgs.add("--data-only");
+        }
+
+        List<String> commands = Stream.of(baseArgs,
                 databaseConfiguration.getExcludeTables().stream()
                         .flatMap(table -> {
                             String fullTableName = databaseConfiguration
@@ -101,44 +121,6 @@ public class DatabaseService {
         }
 
         System.out.println("Dump created");
-
-        return outputFile;
-    }
-
-    public File createDataOnlyDump(String databaseName)
-            throws IOException, InterruptedException {
-        DatabaseConfiguration databaseConfiguration = getDatabaseConfiguration(
-                databaseName);
-        File outputFile = File.createTempFile("pgdump-data-", ".sql");
-        List<String> commands = Stream.of(List.of("pg_dump", "--dbname",
-                databaseConfiguration.getConnectionString(), "--schema",
-                databaseConfiguration.getSchema(), "--format", "plain",
-                "--data-only", "--column-inserts", "--file",
-                outputFile.getAbsolutePath()),
-                databaseConfiguration.getExcludeTables().stream()
-                        .flatMap(table -> {
-                            String fullTableName = databaseConfiguration
-                                    .getSchema() + "." + table;
-                            return List.of("--exclude-table", fullTableName)
-                                    .stream();
-                        }).toList())
-                .flatMap(x -> x.stream()).filter(arg -> !arg.isEmpty())
-                .toList();
-
-        System.out.println("Creating data-only dump: " + String.join(", ", commands));
-
-        int status = new ProcessBuilder(commands).inheritIO().start().waitFor();
-
-        if (status != 0) {
-            throw new RuntimeException("Unable to create data-only dump. pg_dump failed");
-        }
-
-        if (!outputFile.exists()) {
-            throw new RuntimeException(
-                    "Unable to create data-only dump. " + outputFile + " was not created.");
-        }
-
-        System.out.println("Data-only dump created");
         return outputFile;
     }
 

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
@@ -2,6 +2,7 @@ package io.github.mucsi96.postgresbackuptool.service;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -66,8 +67,7 @@ public class DatabaseService {
 
     }
 
-    public File createDump(String databaseName, int retentionPeriod,
-            String format, String timeString)
+    public File createDump(String databaseName, String format)
             throws IOException, InterruptedException {
         return executePgDump(databaseName, format, false);
     }
@@ -84,7 +84,7 @@ public class DatabaseService {
         String suffix = "plain".equals(format) ? ".sql" : ".pgdump";
         File outputFile = File.createTempFile("pgdump-", suffix);
 
-        List<String> baseArgs = new java.util.ArrayList<>(List.of("pg_dump",
+        List<String> baseArgs = new ArrayList<>(List.of("pg_dump",
                 "--dbname", databaseConfiguration.getConnectionString(),
                 "--schema", databaseConfiguration.getSchema(), "--format",
                 format, "--file", outputFile.getAbsolutePath()));
@@ -109,19 +109,29 @@ public class DatabaseService {
 
         System.out.println("Creating dump: " + String.join(", ", commands));
 
-        int status = new ProcessBuilder(commands).inheritIO().start().waitFor();
+        boolean success = false;
+        try {
+            int status = new ProcessBuilder(commands).inheritIO().start()
+                    .waitFor();
 
-        if (status != 0) {
-            throw new RuntimeException("Unable to create dump. pg_dump failed");
+            if (status != 0) {
+                throw new RuntimeException(
+                        "Unable to create dump. pg_dump failed");
+            }
+
+            if (!outputFile.exists()) {
+                throw new RuntimeException("Unable to create dump. "
+                        + outputFile + " was not created.");
+            }
+
+            System.out.println("Dump created");
+            success = true;
+            return outputFile;
+        } finally {
+            if (!success) {
+                outputFile.delete();
+            }
         }
-
-        if (!outputFile.exists()) {
-            throw new RuntimeException(
-                    "Unable to create dump. " + outputFile + " was not created.");
-        }
-
-        System.out.println("Dump created");
-        return outputFile;
     }
 
     public void restoreDump(String databaseName, File dumpFile)

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
@@ -105,6 +105,43 @@ public class DatabaseService {
         return outputFile;
     }
 
+    public File createDataOnlyDump(String databaseName)
+            throws IOException, InterruptedException {
+        DatabaseConfiguration databaseConfiguration = getDatabaseConfiguration(
+                databaseName);
+        File outputFile = File.createTempFile("pgdump-data-", ".sql");
+        List<String> commands = Stream.of(List.of("pg_dump", "--dbname",
+                databaseConfiguration.getConnectionString(), "--schema",
+                databaseConfiguration.getSchema(), "--format", "plain",
+                "--data-only", "--column-inserts", "--file",
+                outputFile.getAbsolutePath()),
+                databaseConfiguration.getExcludeTables().stream()
+                        .flatMap(table -> {
+                            String fullTableName = databaseConfiguration
+                                    .getSchema() + "." + table;
+                            return List.of("--exclude-table", fullTableName)
+                                    .stream();
+                        }).toList())
+                .flatMap(x -> x.stream()).filter(arg -> !arg.isEmpty())
+                .toList();
+
+        System.out.println("Creating data-only dump: " + String.join(", ", commands));
+
+        int status = new ProcessBuilder(commands).inheritIO().start().waitFor();
+
+        if (status != 0) {
+            throw new RuntimeException("Unable to create data-only dump. pg_dump failed");
+        }
+
+        if (!outputFile.exists()) {
+            throw new RuntimeException(
+                    "Unable to create data-only dump. " + outputFile + " was not created.");
+        }
+
+        System.out.println("Data-only dump created");
+        return outputFile;
+    }
+
     public void restoreDump(String databaseName, File dumpFile)
             throws IOException, InterruptedException {
         DatabaseConfiguration databaseConfiguration = getDatabaseConfiguration(

--- a/test/tests/test_export_sql.spec.ts
+++ b/test/tests/test_export_sql.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '../fixtures';
+import { populateDb } from '../utils';
+import { readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+test.describe('Export SQL Tests', () => {
+  test('downloads data-only SQL export with INSERT statements', async ({
+    page,
+  }) => {
+    await populateDb();
+
+    await page.goto('http://localhost:8280');
+    await page.getByText('db1').click();
+    await expect(
+      page.getByRole('heading', { name: 'Records' })
+    ).toHaveText('Records 9');
+
+    // Click the Export SQL button and wait for download
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export SQL' }).click();
+    const download = await downloadPromise;
+
+    // Verify filename
+    expect(download.suggestedFilename()).toBe('db1-data-export.sql');
+
+    // Save and verify content
+    const filePath = join(tmpdir(), download.suggestedFilename());
+    await download.saveAs(filePath);
+
+    const content = await readFile(filePath, 'utf-8');
+
+    // Verify it contains INSERT statements (data-only)
+    expect(content).toContain('INSERT INTO');
+
+    // Verify it does NOT contain CREATE TABLE (schema)
+    expect(content).not.toContain('CREATE TABLE');
+
+    // Verify actual data from the fruites table
+    expect(content).toContain('Apple');
+    expect(content).toContain('Orange');
+    expect(content).toContain('Banana');
+    expect(content).toContain('Rasberry');
+
+    // Verify actual data from the vegetables table
+    expect(content).toContain('Carrot');
+    expect(content).toContain('Potato');
+    expect(content).toContain('Spinach');
+    expect(content).toContain('Broccoli');
+    expect(content).toContain('Tomato');
+
+    // Verify excluded tables are NOT in the export
+    expect(content).not.toContain('INSERT INTO test1.passwords');
+    expect(content).not.toContain('INSERT INTO test1.secrets');
+  });
+
+  test('exports SQL for second database', async ({ page }) => {
+    await populateDb();
+
+    await page.goto('http://localhost:8280');
+    await page.getByText('db2').click();
+    await expect(
+      page.getByRole('heading', { name: 'Records' })
+    ).toHaveText('Records 17');
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export SQL' }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe('db2-data-export.sql');
+
+    const filePath = join(tmpdir(), download.suggestedFilename());
+    await download.saveAs(filePath);
+
+    const content = await readFile(filePath, 'utf-8');
+
+    // Verify data from db2 tables
+    expect(content).toContain('INSERT INTO');
+    expect(content).not.toContain('CREATE TABLE');
+    expect(content).toContain('Dog');
+    expect(content).toContain('Harry Potter');
+    expect(content).toContain('USA');
+
+    // Verify excluded tables are NOT in the export
+    expect(content).not.toContain('INSERT INTO test2.secrets');
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds the ability to export table data as SQL INSERT statements from the database. Users can now download a data-only SQL dump through a new "Export SQL" button in the tables interface.

## Key Changes
- **Backend Service**: Added `createDataOnlyDump()` method to `DatabaseService` that generates a data-only SQL dump using `pg_dump` with `--data-only` and `--column-inserts` flags, excluding configured tables
- **Download Endpoint**: Extended `DownloadController` to handle "data-export" type downloads, generating the SQL dump on-demand when a download token is used
- **API Endpoint**: Added new POST endpoint `/api/database/{database_name}/export-sql/download-token` in `BackupController` to create download tokens for SQL exports with appropriate authorization checks
- **Frontend Service**: Implemented `exportSql()` method in `TablesService` to request the download token and initiate the file download
- **UI Component**: Added "Export SQL" button to the tables component that triggers the export functionality with processing state management

## Implementation Details
- The data-only dump uses column-inserts format for better readability and compatibility
- Excluded tables are properly filtered using the schema-qualified table names
- Download tokens are created with type "data-export" to distinguish from backup downloads
- The exported file is named `{database_name}-data-export.sql` and served as plain text
- Error handling is implemented at both service and UI levels with user notifications

https://claude.ai/code/session_01SnS6i7UgL8DUcqo3RqYaw6