### PR TITLE
Add OID environment variable to test pod configuration

### DIFF
--- a/test/test-pod.yaml
+++ b/test/test-pod.yaml
@@ -98,6 +98,8 @@ spec:
           value: default
         - name: SUB
           value: test-user
+        - name: OID
+          value: 00000000-0000-0000-0000-000000000001
         - name: NAME
           value: Test User
         - name: PREFERRED_USERNAME


### PR DESCRIPTION
## Summary
Added the OID (Object Identifier) environment variable to the test pod specification to support testing scenarios that require a unique identifier.

## Changes
- Added `OID` environment variable with a UUID value (`00000000-0000-0000-0000-000000000001`) to the pod's environment configuration in the test manifest

## Details
The OID environment variable is positioned between the `SUB` and `NAME` variables in the environment configuration, following the existing naming convention for test user identity attributes.

https://claude.ai/code/session_01ParBajucCXQVkiZ4xPR2vm