### PR TITLE
Fetch database config from Key Vault on demand instead of at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ internal to the pod network and reached by Traefik on `127.0.0.1`.
 
 ## Database configuration
 
-In production, the database configuration is stored as the `dbs-config` secret in Azure Key Vault and loaded automatically via Spring Cloud Azure. The secret value is a JSON array:
+In production, the database configuration is stored as the `dbs-config` secret in Azure Key Vault and fetched on demand each time the application needs it, so the secret can be updated without redeploying. The secret value is a JSON array:
 
 ```json
 [

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfigurationProviderConfig.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfigurationProviderConfig.java
@@ -10,45 +10,82 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 public class DatabaseConfigurationProviderConfig {
 
-    @Value("${dbs-config:}")
-    String databasesConfig;
+    @Bean
+    @Profile({ "prod", "local" })
+    SecretClient databaseConfigSecretClient(
+            @Value("${keyvault-endpoint}") String keyvaultEndpoint) {
+        return new SecretClientBuilder().vaultUrl(keyvaultEndpoint)
+                .credential(new DefaultAzureCredentialBuilder().build())
+                .buildClient();
+    }
 
     @Bean
     @Profile("prod")
     DatabaseConfigurationProvider prodDatabaseConfigurationProvider(
-            ObjectMapper objectMapper) throws IOException {
-        List<DatabaseConfiguration> databases = Arrays.asList(objectMapper
-                .readValue(databasesConfig, DatabaseConfiguration[].class));
-        return () -> databases;
+            SecretClient databaseConfigSecretClient,
+            @Value("${databases-config-secret-name}") String secretName,
+            ObjectMapper objectMapper) {
+        return () -> readFromKeyVault(databaseConfigSecretClient, secretName,
+                objectMapper);
     }
 
     @Bean
     @Profile("local")
     DatabaseConfigurationProvider localDatabaseConfigurationProvider(
-            ObjectMapper objectMapper) throws IOException {
-        List<DatabaseConfiguration> databases = Arrays.asList(objectMapper
-                .readValue(databasesConfig, DatabaseConfiguration[].class));
-        // Adjust host to localhost for local development
-        databases.forEach(db -> {
-            db.setHost("localhost");
-            db.setPort(5461);
-        });
-        return () -> databases;
+            SecretClient databaseConfigSecretClient,
+            @Value("${databases-config-secret-name}") String secretName,
+            ObjectMapper objectMapper) {
+        return () -> {
+            List<DatabaseConfiguration> databases = readFromKeyVault(
+                    databaseConfigSecretClient, secretName, objectMapper);
+            // Adjust host to localhost for local development
+            databases.forEach(db -> {
+                db.setHost("localhost");
+                db.setPort(5461);
+            });
+            return databases;
+        };
     }
 
     @Bean
     @Profile("test")
     DatabaseConfigurationProvider testDatabaseConfigurationProvider(
             @Value("${databasesConfigPath}") String databasesConfigPath,
-            ObjectMapper objectMapper) throws IOException {
-        List<DatabaseConfiguration> databases = Arrays.asList(
-                objectMapper.readValue(Paths.get(databasesConfigPath).toFile(),
-                        DatabaseConfiguration[].class));
-        return () -> databases;
+            ObjectMapper objectMapper) {
+        return () -> {
+            try {
+                return Arrays.asList(
+                        objectMapper.readValue(Paths.get(databasesConfigPath)
+                                .toFile(), DatabaseConfiguration[].class));
+            } catch (IOException e) {
+                throw new RuntimeException(
+                        "Failed to read database configurations from "
+                                + databasesConfigPath,
+                        e);
+            }
+        };
+    }
+
+    private static List<DatabaseConfiguration> readFromKeyVault(
+            SecretClient secretClient, String secretName,
+            ObjectMapper objectMapper) {
+        String json = secretClient.getSecret(secretName).getValue();
+        try {
+            return Arrays.asList(objectMapper.readValue(json,
+                    DatabaseConfiguration[].class));
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Failed to parse database configurations from secret "
+                            + secretName,
+                    e);
+        }
     }
 }

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
@@ -20,22 +20,23 @@ import io.github.mucsi96.postgresbackuptool.model.Table;
 
 @Service
 public class DatabaseService {
-    private final List<DatabaseConfiguration> databases;
+    private final DatabaseConfigurationProvider configurationProvider;
 
     public DatabaseService(DatabaseConfigurationProvider configurationProvider) {
-        this.databases = configurationProvider.getDatabaseConfigurations();
+        this.configurationProvider = configurationProvider;
     }
 
     public List<DatabaseConfiguration> getDatabases() {
-        return databases;
+        return configurationProvider.getDatabaseConfigurations();
     }
 
     public List<String> getDatabaseNames() {
-        return databases.stream().map(DatabaseConfiguration::getName).toList();
+        return getDatabases().stream().map(DatabaseConfiguration::getName)
+                .toList();
     }
 
     public DatabaseConfiguration getDatabaseConfiguration(String databaseName) {
-        return databases.stream()
+        return getDatabases().stream()
                 .filter(db -> db.getName().equals(databaseName)).findFirst()
                 .orElseThrow(() -> new RuntimeException("Database with name "
                         + databaseName + " not found in configuration"));

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+keyvault-endpoint: https://p06-backup.vault.azure.net/
+databases-config-secret-name: dbs-config
+
 server:
   servlet:
     context-path: /api
@@ -7,7 +10,7 @@ spring:
       keyvault:
         secret:
           property-sources:
-            - endpoint: https://p06-backup.vault.azure.net/
+            - endpoint: ${keyvault-endpoint}
               enabled: true
 
       storage:


### PR DESCRIPTION
## Summary
Refactored database configuration loading to fetch from Azure Key Vault on demand rather than at application startup. This allows database configuration updates without requiring application redeployment.

## Key Changes
- **DatabaseConfigurationProviderConfig.java**
  - Added `SecretClient` bean to interact with Azure Key Vault
  - Extracted common Key Vault reading logic into `readFromKeyVault()` helper method
  - Modified `prodDatabaseConfigurationProvider` to fetch secrets on demand via lambda
  - Modified `localDatabaseConfigurationProvider` to fetch secrets on demand while maintaining localhost overrides
  - Modified `testDatabaseConfigurationProvider` to defer file reading to runtime with proper error handling
  - Removed `@Value("${dbs-config:}")` field and moved configuration to property-based approach
  - Added proper exception handling with descriptive error messages for IO failures

- **DatabaseService.java**
  - Changed from storing database list at construction time to storing the `DatabaseConfigurationProvider` reference
  - Updated all methods to call `getDatabaseConfigurations()` on demand instead of using cached list
  - This ensures the service always uses the latest configuration from Key Vault

- **application.yml**
  - Added `keyvault-endpoint` and `databases-config-secret-name` as top-level configuration properties
  - Updated Spring Cloud Azure Key Vault endpoint to use the new property variable

- **README.md**
  - Updated documentation to clarify that secrets are now fetched on demand rather than loaded at startup

## Implementation Details
- Configuration is now fetched lazily through the `DatabaseConfigurationProvider` interface, allowing runtime updates
- Error handling improved with try-catch blocks that wrap checked exceptions in RuntimeExceptions with contextual messages
- The local profile still applies localhost overrides to the fetched configuration
- Test profile continues to read from local file system with deferred loading

https://claude.ai/code/session_01ViwztzhNE7A15eDdxb5yzA