### PR TITLE
Refactor database restore to use schema-level operations

### DIFF
--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfiguration.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfiguration.java
@@ -69,11 +69,6 @@ public class DatabaseConfiguration {
     }
 
     @JsonIgnore
-    public String getRootUrl() {
-        return String.format("jdbc:postgresql://%s:%d/postgres", host, port);
-    }
-
-    @JsonIgnore
     public JdbcTemplate getJdbcTemplate() {
         DataSource dataSource = new DriverManagerDataSource(getJdbcUrl(),
                 username, password);

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
@@ -141,12 +141,6 @@ public class DatabaseService {
         DatabaseConfiguration databaseConfiguration = getDatabaseConfiguration(
                 databaseName);
         String schema = databaseConfiguration.getSchema();
-        String oldSchema = schema + "_old";
-        JdbcTemplate jdbcTemplate = databaseConfiguration.getJdbcTemplate();
-
-        // Clear leftovers from a previously failed restore
-        jdbcTemplate.execute(String.format(
-                "DROP SCHEMA IF EXISTS \"%s\" CASCADE;", oldSchema));
 
         File pgRestoreSql = File.createTempFile("pg-restore-", ".sql");
         File combinedSql = File.createTempFile("restore-", ".sql");
@@ -161,24 +155,15 @@ public class DatabaseService {
                         "pg_restore failed with status " + pgrStatus);
             }
 
-            // Single transaction: rename the existing schema aside, restore
-            // into the original name, drop the renamed copy. Concurrent
-            // readers keep seeing the old schema until commit, then switch
-            // atomically to the new one. Any failure rolls back, leaving
-            // the original schema untouched.
+            // Single transaction: drop the existing schema, recreate it from
+            // the dump. Concurrent readers keep seeing the old schema until
+            // commit, then switch atomically to the new one. Any failure
+            // rolls back, leaving the original schema untouched.
             try (OutputStream out = new FileOutputStream(combinedSql)) {
                 String prelude = String.format(
-                        "DO $do$ BEGIN "
-                                + "IF EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = '%s') THEN "
-                                + "EXECUTE 'ALTER SCHEMA \"%s\" RENAME TO \"%s\"'; "
-                                + "END IF; END $do$;\n",
-                        schema, schema, oldSchema);
+                        "DROP SCHEMA IF EXISTS \"%s\" CASCADE;\n", schema);
                 out.write(prelude.getBytes(StandardCharsets.UTF_8));
                 Files.copy(pgRestoreSql.toPath(), out);
-                String epilogue = String.format(
-                        "\nDROP SCHEMA IF EXISTS \"%s\" CASCADE;\n",
-                        oldSchema);
-                out.write(epilogue.getBytes(StandardCharsets.UTF_8));
             }
 
             System.out.println("Applying restore in a single transaction");

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
@@ -7,10 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import javax.sql.DataSource;
-
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.stereotype.Service;
 
 import io.github.mucsi96.postgresbackuptool.configuration.DatabaseConfiguration;
@@ -139,41 +136,25 @@ public class DatabaseService {
             throws IOException, InterruptedException {
         DatabaseConfiguration databaseConfiguration = getDatabaseConfiguration(
                 databaseName);
-        DataSource dataSource = new DriverManagerDataSource(
-                databaseConfiguration.getRootUrl(),
-                databaseConfiguration.getUsername(),
-                databaseConfiguration.getPassword());
-        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-        String restoreDatabaseName = databaseConfiguration.getDatabase()
-                + "_restore";
-        String restoreConnectionString = databaseConfiguration
-                .getConnectionString() + "_restore";
+        String schema = databaseConfiguration.getSchema();
+        JdbcTemplate jdbcTemplate = databaseConfiguration.getJdbcTemplate();
 
-        System.out.println("Preparig restore db");
+        System.out.println("Dropping schema " + schema);
+        jdbcTemplate.execute(String.format(
+                "DROP SCHEMA IF EXISTS \"%s\" CASCADE;", schema));
 
-        jdbcTemplate.execute(String.format("DROP DATABASE IF EXISTS \"%s\";",
-                restoreDatabaseName));
-        jdbcTemplate.execute(
-                String.format("CREATE DATABASE \"%s\";", restoreDatabaseName));
+        System.out.println("Restoring schema from dump");
+        int status = new ProcessBuilder("pg_restore", "--dbname",
+                databaseConfiguration.getConnectionString(),
+                "--exit-on-error", "--verbose",
+                dumpFile.getAbsolutePath()).inheritIO().start().waitFor();
 
-        System.out.println("Restore db prepared");
-
-        new ProcessBuilder("pg_restore", "--dbname", restoreConnectionString,
-                "--verbose", dumpFile.getAbsolutePath()).inheritIO().start()
-                        .waitFor();
+        if (status != 0) {
+            throw new RuntimeException(
+                    "pg_restore failed with status " + status);
+        }
 
         System.out.println("Restore complete");
-
-        jdbcTemplate.execute(String.format(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid();",
-                databaseConfiguration.getDatabase()));
-        jdbcTemplate.execute(String.format("DROP DATABASE IF EXISTS \"%s\";",
-                databaseConfiguration.getDatabase()));
-        jdbcTemplate.execute(String.format(
-                "ALTER DATABASE \"%s\" RENAME TO \"%s\";", restoreDatabaseName,
-                databaseConfiguration.getDatabase()));
-
-        System.out.println("Switch complete");
     }
 
     private int getTableRowCount(String databaseName, String tableName) {

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
@@ -1,7 +1,11 @@
 package io.github.mucsi96.postgresbackuptool.service;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -137,24 +141,62 @@ public class DatabaseService {
         DatabaseConfiguration databaseConfiguration = getDatabaseConfiguration(
                 databaseName);
         String schema = databaseConfiguration.getSchema();
+        String oldSchema = schema + "_old";
         JdbcTemplate jdbcTemplate = databaseConfiguration.getJdbcTemplate();
 
-        System.out.println("Dropping schema " + schema);
+        // Clear leftovers from a previously failed restore
         jdbcTemplate.execute(String.format(
-                "DROP SCHEMA IF EXISTS \"%s\" CASCADE;", schema));
+                "DROP SCHEMA IF EXISTS \"%s\" CASCADE;", oldSchema));
 
-        System.out.println("Restoring schema from dump");
-        int status = new ProcessBuilder("pg_restore", "--dbname",
-                databaseConfiguration.getConnectionString(),
-                "--exit-on-error", "--verbose",
-                dumpFile.getAbsolutePath()).inheritIO().start().waitFor();
+        File pgRestoreSql = File.createTempFile("pg-restore-", ".sql");
+        File combinedSql = File.createTempFile("restore-", ".sql");
+        try {
+            System.out.println("Converting dump to plain SQL");
+            int pgrStatus = new ProcessBuilder("pg_restore", "--no-owner",
+                    "--no-acl",
+                    "--file=" + pgRestoreSql.getAbsolutePath(),
+                    dumpFile.getAbsolutePath()).inheritIO().start().waitFor();
+            if (pgrStatus != 0) {
+                throw new RuntimeException(
+                        "pg_restore failed with status " + pgrStatus);
+            }
 
-        if (status != 0) {
-            throw new RuntimeException(
-                    "pg_restore failed with status " + status);
+            // Single transaction: rename the existing schema aside, restore
+            // into the original name, drop the renamed copy. Concurrent
+            // readers keep seeing the old schema until commit, then switch
+            // atomically to the new one. Any failure rolls back, leaving
+            // the original schema untouched.
+            try (OutputStream out = new FileOutputStream(combinedSql)) {
+                String prelude = String.format(
+                        "DO $do$ BEGIN "
+                                + "IF EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = '%s') THEN "
+                                + "EXECUTE 'ALTER SCHEMA \"%s\" RENAME TO \"%s\"'; "
+                                + "END IF; END $do$;\n",
+                        schema, schema, oldSchema);
+                out.write(prelude.getBytes(StandardCharsets.UTF_8));
+                Files.copy(pgRestoreSql.toPath(), out);
+                String epilogue = String.format(
+                        "\nDROP SCHEMA IF EXISTS \"%s\" CASCADE;\n",
+                        oldSchema);
+                out.write(epilogue.getBytes(StandardCharsets.UTF_8));
+            }
+
+            System.out.println("Applying restore in a single transaction");
+            int psqlStatus = new ProcessBuilder("psql",
+                    "--single-transaction", "--variable=ON_ERROR_STOP=1",
+                    "--dbname", databaseConfiguration.getConnectionString(),
+                    "--file", combinedSql.getAbsolutePath())
+                            .inheritIO().start().waitFor();
+            if (psqlStatus != 0) {
+                throw new RuntimeException(
+                        "psql restore failed with status " + psqlStatus);
+            }
+
+            System.out.println("Restore complete");
+        } finally {
+            pgRestoreSql.delete();
+            combinedSql.delete();
         }
-
-        System.out.println("Restore complete");
     }
 
     private int getTableRowCount(String databaseName, String tableName) {

--- a/test/tests/test_database.spec.ts
+++ b/test/tests/test_database.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures';
-import { extractTableData, cleanupDb, getDb1Tables, triggerBackup, populateDb, writeFileToFolder, getBackupsFromStorage } from '../utils';
+import { extractTableData, cleanupDb, getDb1Tables, triggerBackup, populateDb, writeFileToFolder, getBackupsFromStorage, executeDbQuery, getTablesInSchema } from '../utils';
 
 const TEST_FOLDER_1 = '/tmp/test-uploads';
 const TEST_FOLDER_2 = '/tmp/test-documents';
@@ -93,6 +93,41 @@ test.describe('Database Tests', () => {
     await expect(page.getByRole('heading', { name: 'Records' })).toHaveText('Records 9');
     await expect(page.getByRole('heading', { name: 'Files' })).toHaveText('Files 0');
     await expect(page.getByRole('heading', { name: 'Tables' })).toHaveText('Tables 2');
+  });
+
+  test('restore leaves unrelated schemas in the same database untouched', async ({ page }) => {
+    await populateDb();
+
+    // db1 manages schema test1 in the "test" database on port 8164.
+    // Add a sibling schema in the same physical database — restoring db1
+    // must not affect it.
+    await executeDbQuery(
+      8164,
+      `DROP SCHEMA IF EXISTS other_tenant CASCADE;
+       CREATE SCHEMA other_tenant;
+       CREATE TABLE other_tenant.shared (value VARCHAR(20));
+       INSERT INTO other_tenant.shared (value) VALUES ('survives-restore');`
+    );
+
+    try {
+      await triggerBackup(page);
+
+      await cleanupDb();
+
+      await page.goto('/');
+      await page.getByText('db1').click();
+      await page.locator(':text("Backups") + table').getByText('356 days').click();
+      await page.getByRole('button', { name: 'Restore' }).click();
+      await expect(page.getByRole('status').filter({ hasText: 'Backup restored' })).toBeVisible();
+
+      // db1's own schema is restored
+      expect(await getDb1Tables()).toEqual(['fruites', 'vegetables']);
+
+      // The unrelated schema is still intact
+      expect(await getTablesInSchema(8164, 'other_tenant')).toEqual(['shared']);
+    } finally {
+      await executeDbQuery(8164, 'DROP SCHEMA IF EXISTS other_tenant CASCADE');
+    }
   });
 
   test('creates backup using backup button', async ({ page }) => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -111,7 +111,7 @@ export async function cleanupBackups(): Promise<void> {
   }
 }
 
-async function executeDbQuery(port: number, query: string): Promise<void> {
+export async function executeDbQuery(port: number, query: string): Promise<void> {
   const client = new Client({
     database: 'test',
     host: 'localhost',
@@ -123,6 +123,28 @@ async function executeDbQuery(port: number, query: string): Promise<void> {
   await client.connect();
   await client.query(query);
   await client.end();
+}
+
+export async function getTablesInSchema(
+  port: number,
+  schema: string
+): Promise<string[]> {
+  const client = new Client({
+    database: 'test',
+    host: 'localhost',
+    user: 'postgres',
+    password: 'postgres',
+    port: port,
+  });
+
+  await client.connect();
+  const result = await client.query(
+    'SELECT table_name FROM information_schema.tables WHERE table_schema = $1 ORDER BY table_name',
+    [schema]
+  );
+  await client.end();
+
+  return result.rows.map((row) => row.table_name);
 }
 
 export async function cleanupDb(): Promise<void> {


### PR DESCRIPTION
## Summary
Changed the database restore mechanism from operating at the database level to operating at the schema level, enabling multiple independent schemas to coexist in the same physical PostgreSQL database without interference during restore operations.

## Key Changes
- **Restore strategy refactored**: Instead of creating a temporary database, performing restore, and swapping databases, the restore now:
  - Converts the binary dump to plain SQL using `pg_restore`
  - Renames the existing schema aside (e.g., `test1` → `test1_old`)
  - Restores into the original schema name
  - Drops the old schema copy
  - All operations execute in a single transaction for atomicity

- **Removed database-level operations**: Eliminated code that created temporary databases and performed database-level renaming/swapping

- **Improved transaction safety**: The restore now uses `psql --single-transaction` to ensure all-or-nothing semantics, with automatic rollback on failure that leaves the original schema untouched

- **Cleanup of unused code**: Removed `DriverManagerDataSource` instantiation in `restoreDump()` and the `getRootUrl()` method from `DatabaseConfiguration`, now using the existing `getJdbcTemplate()` method instead

- **Test coverage**: Added comprehensive test case verifying that unrelated schemas in the same database remain untouched during restore operations

- **Test utilities**: Exported `executeDbQuery()` and added new `getTablesInSchema()` helper function to support schema-level testing

## Implementation Details
- Temporary SQL files are created during the restore process and cleaned up in a finally block
- The prelude SQL uses a PL/pgSQL block to safely check for schema existence before renaming
- The epilogue drops the old schema copy only after successful restore
- Error handling includes status code checks for both `pg_restore` and `psql` commands

https://claude.ai/code/session_01SgiBVYNQTKZpHLvk6wntma