### PR TITLE
Exclude table data while preserving schema in backups

### DIFF
--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
@@ -103,7 +103,8 @@ public class DatabaseService {
                         .flatMap(table -> {
                             String fullTableName = databaseConfiguration
                                     .getSchema() + "." + table;
-                            return List.of("--exclude-table", fullTableName)
+                            return List
+                                    .of("--exclude-table-data", fullTableName)
                                     .stream();
                         }).toList())
                 .flatMap(x -> x.stream()).filter(arg -> !arg.isEmpty())

--- a/test/tests/test_backups.spec.ts
+++ b/test/tests/test_backups.spec.ts
@@ -241,5 +241,16 @@ test.describe('Backups Tests', () => {
 
     // Verify SQL content contains expected data from the populated database
     expect(content).toContain('test1');
+
+    // Verify the structure (CREATE TABLE) for excluded tables IS included
+    // so the application can keep working after restore
+    expect(content).toMatch(/CREATE TABLE[^;]*test1\.passwords/);
+    expect(content).toMatch(/CREATE TABLE[^;]*test1\.secrets/);
+
+    // But the data (rows) for excluded tables must NOT be included
+    expect(content).not.toContain('INSERT INTO test1.passwords');
+    expect(content).not.toContain("COPY test1.passwords");
+    expect(content).not.toContain('INSERT INTO test1.secrets');
+    expect(content).not.toContain("COPY test1.secrets");
   });
 });

--- a/test/tests/test_database.spec.ts
+++ b/test/tests/test_database.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures';
-import { extractTableData, cleanupDb, getDb1Tables, triggerBackup, populateDb, writeFileToFolder, getBackupsFromStorage, executeDbQuery, getTablesInSchema } from '../utils';
+import { extractTableData, cleanupDb, getDb1Tables, triggerBackup, populateDb, writeFileToFolder, getBackupsFromStorage, executeDbQuery, getTablesInSchema, getTableRowCount } from '../utils';
 
 const TEST_FOLDER_1 = '/tmp/test-uploads';
 const TEST_FOLDER_2 = '/tmp/test-documents';
@@ -120,8 +120,14 @@ test.describe('Database Tests', () => {
       await page.getByRole('button', { name: 'Restore' }).click();
       await expect(page.getByRole('status').filter({ hasText: 'Backup restored' })).toBeVisible();
 
-      // db1's own schema is restored
-      expect(await getDb1Tables()).toEqual(['fruites', 'vegetables']);
+      // db1's own schema is restored — excluded tables are recreated
+      // (empty) so the application keeps working.
+      expect(await getDb1Tables()).toEqual([
+        'fruites',
+        'passwords',
+        'secrets',
+        'vegetables',
+      ]);
 
       // The unrelated schema is still intact
       expect(await getTablesInSchema(8164, 'other_tenant')).toEqual(['shared']);
@@ -145,7 +151,7 @@ test.describe('Database Tests', () => {
     expect(backups[0].rowsCount).toBe(9);
   });
 
-  test('doesnt restore excluded tables', async ({ page }) => {
+  test('restores excluded tables empty', async ({ page }) => {
     await populateDb();
 
     await triggerBackup(page);
@@ -158,7 +164,14 @@ test.describe('Database Tests', () => {
     await page.getByRole('button', { name: 'Restore' }).click();
     await expect(page.getByRole('status').filter({ hasText: 'Backup restored' })).toBeVisible();
 
+    // Excluded tables must be recreated so the application can keep
+    // working — only their rows are skipped.
     const tables = await getDb1Tables();
-    expect(tables).toEqual(['fruites', 'vegetables']);
+    expect(tables).toEqual(['fruites', 'passwords', 'secrets', 'vegetables']);
+
+    expect(await getTableRowCount(8164, 'test1', 'fruites')).toBe(4);
+    expect(await getTableRowCount(8164, 'test1', 'vegetables')).toBe(5);
+    expect(await getTableRowCount(8164, 'test1', 'passwords')).toBe(0);
+    expect(await getTableRowCount(8164, 'test1', 'secrets')).toBe(0);
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -147,6 +147,28 @@ export async function getTablesInSchema(
   return result.rows.map((row) => row.table_name);
 }
 
+export async function getTableRowCount(
+  port: number,
+  schema: string,
+  table: string
+): Promise<number> {
+  const client = new Client({
+    database: 'test',
+    host: 'localhost',
+    user: 'postgres',
+    password: 'postgres',
+    port: port,
+  });
+
+  await client.connect();
+  const result = await client.query(
+    `SELECT COUNT(*)::int AS count FROM "${schema}"."${table}"`
+  );
+  await client.end();
+
+  return result.rows[0].count;
+}
+
 export async function cleanupDb(): Promise<void> {
   await executeDbQuery(8164, 'DROP SCHEMA IF EXISTS test1 CASCADE');
   await executeDbQuery(8165, 'DROP SCHEMA IF EXISTS test2 CASCADE');


### PR DESCRIPTION
## Summary
Changed the backup exclusion strategy to preserve table schemas for excluded tables while omitting their data. This ensures the application can function correctly after restoring a backup, even when sensitive tables are excluded from the data dump.

## Key Changes
- Modified `DatabaseService.java` to use `--exclude-table-data` instead of `--exclude-table` when executing pg_dump
  - This preserves CREATE TABLE statements for excluded tables
  - Prevents INSERT/COPY statements for excluded table data from being included in the backup
- Added comprehensive test coverage in `test_backups.spec.ts` to verify:
  - CREATE TABLE statements for excluded tables (passwords, secrets) are present in the backup
  - INSERT INTO and COPY statements for excluded tables are absent from the backup

## Implementation Details
The change switches from completely excluding tables (`--exclude-table`) to only excluding table data (`--exclude-table-data`). This allows the backup to include the table structure needed for the application schema while excluding sensitive data rows, providing a better balance between data protection and application functionality.

https://claude.ai/code/session_01MtUB7Nv4NfiLrFUbZUwFsH