### PR TITLE
Simplify database config loading with Spring Cloud Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ host, only **8160–8166** are exposed.
 
 ## Database configuration
 
-In production, the database configuration is stored as the `dbs-config` secret in Azure Key Vault and fetched on demand each time the application needs it, so the secret can be updated without redeploying. The secret value is a JSON array:
+In production, the database configuration is stored as the `dbs-config` secret in Azure Key Vault and loaded automatically via Spring Cloud Azure. The secret value is a JSON array:
 
 ```json
 [

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfigurationProviderConfig.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfigurationProviderConfig.java
@@ -10,82 +10,45 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-import com.azure.identity.DefaultAzureCredentialBuilder;
-import com.azure.security.keyvault.secrets.SecretClient;
-import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 public class DatabaseConfigurationProviderConfig {
 
-    @Bean
-    @Profile({ "prod", "local" })
-    SecretClient databaseConfigSecretClient(
-            @Value("${keyvault-endpoint}") String keyvaultEndpoint) {
-        return new SecretClientBuilder().vaultUrl(keyvaultEndpoint)
-                .credential(new DefaultAzureCredentialBuilder().build())
-                .buildClient();
-    }
+    @Value("${dbs-config:}")
+    String databasesConfig;
 
     @Bean
     @Profile("prod")
     DatabaseConfigurationProvider prodDatabaseConfigurationProvider(
-            SecretClient databaseConfigSecretClient,
-            @Value("${databases-config-secret-name}") String secretName,
-            ObjectMapper objectMapper) {
-        return () -> readFromKeyVault(databaseConfigSecretClient, secretName,
-                objectMapper);
+            ObjectMapper objectMapper) throws IOException {
+        List<DatabaseConfiguration> databases = Arrays.asList(objectMapper
+                .readValue(databasesConfig, DatabaseConfiguration[].class));
+        return () -> databases;
     }
 
     @Bean
     @Profile("local")
     DatabaseConfigurationProvider localDatabaseConfigurationProvider(
-            SecretClient databaseConfigSecretClient,
-            @Value("${databases-config-secret-name}") String secretName,
-            ObjectMapper objectMapper) {
-        return () -> {
-            List<DatabaseConfiguration> databases = readFromKeyVault(
-                    databaseConfigSecretClient, secretName, objectMapper);
-            // Adjust host to localhost for local development
-            databases.forEach(db -> {
-                db.setHost("localhost");
-                db.setPort(5461);
-            });
-            return databases;
-        };
+            ObjectMapper objectMapper) throws IOException {
+        List<DatabaseConfiguration> databases = Arrays.asList(objectMapper
+                .readValue(databasesConfig, DatabaseConfiguration[].class));
+        // Adjust host to localhost for local development
+        databases.forEach(db -> {
+            db.setHost("localhost");
+            db.setPort(5461);
+        });
+        return () -> databases;
     }
 
     @Bean
     @Profile("test")
     DatabaseConfigurationProvider testDatabaseConfigurationProvider(
             @Value("${databasesConfigPath}") String databasesConfigPath,
-            ObjectMapper objectMapper) {
-        return () -> {
-            try {
-                return Arrays.asList(
-                        objectMapper.readValue(Paths.get(databasesConfigPath)
-                                .toFile(), DatabaseConfiguration[].class));
-            } catch (IOException e) {
-                throw new RuntimeException(
-                        "Failed to read database configurations from "
-                                + databasesConfigPath,
-                        e);
-            }
-        };
-    }
-
-    private static List<DatabaseConfiguration> readFromKeyVault(
-            SecretClient secretClient, String secretName,
-            ObjectMapper objectMapper) {
-        String json = secretClient.getSecret(secretName).getValue();
-        try {
-            return Arrays.asList(objectMapper.readValue(json,
-                    DatabaseConfiguration[].class));
-        } catch (IOException e) {
-            throw new RuntimeException(
-                    "Failed to parse database configurations from secret "
-                            + secretName,
-                    e);
-        }
+            ObjectMapper objectMapper) throws IOException {
+        List<DatabaseConfiguration> databases = Arrays.asList(
+                objectMapper.readValue(Paths.get(databasesConfigPath).toFile(),
+                        DatabaseConfiguration[].class));
+        return () -> databases;
     }
 }

--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/service/DatabaseService.java
@@ -21,23 +21,22 @@ import io.github.mucsi96.postgresbackuptool.model.Table;
 
 @Service
 public class DatabaseService {
-    private final DatabaseConfigurationProvider configurationProvider;
+    private final List<DatabaseConfiguration> databases;
 
     public DatabaseService(DatabaseConfigurationProvider configurationProvider) {
-        this.configurationProvider = configurationProvider;
+        this.databases = configurationProvider.getDatabaseConfigurations();
     }
 
     public List<DatabaseConfiguration> getDatabases() {
-        return configurationProvider.getDatabaseConfigurations();
+        return databases;
     }
 
     public List<String> getDatabaseNames() {
-        return getDatabases().stream().map(DatabaseConfiguration::getName)
-                .toList();
+        return databases.stream().map(DatabaseConfiguration::getName).toList();
     }
 
     public DatabaseConfiguration getDatabaseConfiguration(String databaseName) {
-        return getDatabases().stream()
+        return databases.stream()
                 .filter(db -> db.getName().equals(databaseName)).findFirst()
                 .orElseThrow(() -> new RuntimeException("Database with name "
                         + databaseName + " not found in configuration"));

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-keyvault-endpoint: ${AZURE_KEYVAULT_ENDPOINT}
-databases-config-secret-name: dbs-config
-
 server:
   forward-headers-strategy: framework
   servlet:
@@ -11,7 +8,7 @@ spring:
       keyvault:
         secret:
           property-sources:
-            - endpoint: ${keyvault-endpoint}
+            - endpoint: ${AZURE_KEYVAULT_ENDPOINT}
               enabled: true
 
       storage:


### PR DESCRIPTION
## Summary
Refactored database configuration loading to leverage Spring Cloud Azure's automatic secret property source injection instead of manually fetching secrets from Azure Key Vault at runtime.

## Key Changes
- **Removed manual Key Vault client**: Eliminated `SecretClient` bean and `DefaultAzureCredentialBuilder` dependency, relying instead on Spring Cloud Azure's built-in secret property source
- **Simplified configuration providers**: 
  - `prod` and `local` profiles now load configuration from the `dbs-config` environment variable (populated by Spring Cloud Azure) instead of fetching on-demand
  - `test` profile updated to match the simplified pattern
  - Removed `readFromKeyVault()` helper method
- **Optimized DatabaseService**: Changed from storing the configuration provider to caching the database list at initialization, eliminating repeated provider calls
- **Updated application.yml**: Removed custom `keyvault-endpoint` and `databases-config-secret-name` properties; now uses Spring Cloud Azure's standard `AZURE_KEYVAULT_ENDPOINT` directly
- **Updated documentation**: Clarified that configuration is now loaded automatically via Spring Cloud Azure rather than fetched on-demand

## Implementation Details
- Database configurations are now loaded once during bean initialization and cached, improving performance
- The `dbs-config` secret from Azure Key Vault is automatically injected as the `dbs-config` environment variable by Spring Cloud Azure
- All three profiles (prod, local, test) now follow a consistent initialization pattern with proper error handling via `throws IOException`

https://claude.ai/code/session_018wau4DETduvx6shfVNsAqQ