### PR TITLE
Add Prometheus metrics and filter kube-probe logs from nginx

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,6 +1,13 @@
+map $http_user_agent $loggable {
+    ~kube-probe 0;
+    default     1;
+}
+
 server {
     listen 8000;
     listen [::]:8000;
+
+    access_log /var/log/nginx/access.log combined if=$loggable;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>


### PR DESCRIPTION
## Summary
This PR adds observability improvements by enabling Prometheus metrics collection and reducing log noise from Kubernetes health probes in the nginx access logs.

## Key Changes
- **Nginx configuration**: Added conditional logging to exclude kube-probe requests from access logs, reducing log volume from Kubernetes liveness/readiness probes
- **Server dependencies**: Added Micrometer Prometheus registry to enable metrics collection and exposure via the Spring Boot Actuator endpoint

## Implementation Details
- The nginx `map` directive creates a `$loggable` variable that returns 0 for requests matching the kube-probe user agent pattern, effectively filtering them from access logs
- The `micrometer-registry-prometheus` dependency (runtime scope) integrates with Spring Boot Actuator to automatically expose application metrics in Prometheus format
- These changes work together to provide better observability while keeping logs clean and focused on actual application traffic

https://claude.ai/code/session_01JCxRiiPMxA5SHPes9d39Ea