### PR TITLE
Add getter method for folderBackups in DatabaseConfiguration

### DIFF
--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfiguration.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfiguration.java
@@ -51,6 +51,10 @@ public class DatabaseConfiguration {
 
     private List<FolderBackupConfig> folderBackups = List.of();
 
+    public List<FolderBackupConfig> getFolderBackups() {
+        return folderBackups == null ? List.of() : folderBackups;
+    }
+
     @JsonIgnore
     public String getPrefix() {
         return name.toLowerCase().replaceAll("[^a-zA-Z0-9]", "-");


### PR DESCRIPTION
## Summary
Added a public getter method for the `folderBackups` field in `DatabaseConfiguration` class with null-safety handling.

## Key Changes
- Added `getFolderBackups()` method that returns the `folderBackups` list
- Implemented null-safe getter that returns an empty list if `folderBackups` is null, preventing potential `NullPointerException`s

## Implementation Details
The getter follows a defensive programming pattern by checking if `folderBackups` is null and returning `List.of()` (an immutable empty list) as a fallback. This ensures callers always receive a valid list instance regardless of the field's initialization state.

https://claude.ai/code/session_01AjKMAbxH6MZz71SbXZhM8A