### PR TITLE
Add getter method for excludeTables in DatabaseConfiguration

### DIFF
--- a/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfiguration.java
+++ b/server/src/main/java/io/github/mucsi96/postgresbackuptool/configuration/DatabaseConfiguration.java
@@ -51,6 +51,10 @@ public class DatabaseConfiguration {
 
     private List<FolderBackupConfig> folderBackups = List.of();
 
+    public List<String> getExcludeTables() {
+        return excludeTables == null ? List.of() : excludeTables;
+    }
+
     public List<FolderBackupConfig> getFolderBackups() {
         return folderBackups == null ? List.of() : folderBackups;
     }


### PR DESCRIPTION
## Summary
Added a public getter method for the `excludeTables` field in the `DatabaseConfiguration` class to provide consistent access to the exclude tables list.

## Key Changes
- Added `getExcludeTables()` method that returns an empty list if `excludeTables` is null, following the same pattern as the existing `getFolderBackups()` method
- This ensures safe access to the excludeTables configuration without null pointer risks

## Implementation Details
The getter method follows the existing null-safety pattern used in the class, returning an empty `List.of()` when the field is null rather than returning null directly. This maintains consistency with other similar getter methods in the configuration class.

https://claude.ai/code/session_0116Bkc8ukYGCtHUhxNrF4at