### PR TITLE
Adjust resource requests and limits for postgres backup server

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -48,9 +48,9 @@ helm upgrade postgres-azure-backup-server mucsi96/spring-app \
     --set persistentVolumeClaims[0].storageClassName="" \
     --set persistentVolumeClaims[0].storage=5Gi \
     --set resources.requests.memory=512Mi \
-    --set resources.requests.cpu=500m \
+    --set resources.requests.cpu=50m \
     --set resources.limits.memory=1Gi \
-    --set resources.limits.cpu=1 \
+    --set resources.limits.cpu=500m \
     --wait
 
 echo "Deploying client: $DOCKERHUB_USERNAME/postgres-azure-backup-client:$clientLatestTag to $HOSTNAME using client-app chart $clientAppChartVersion"


### PR DESCRIPTION
## Summary
Updated CPU resource configurations for the postgres-azure-backup-server Helm deployment to optimize resource allocation.

## Key Changes
- Reduced CPU request from 500m to 50m to better match actual application needs
- Reduced CPU limit from 1 (1000m) to 500m for more conservative resource constraints
- Memory configurations remain unchanged (512Mi request, 1Gi limit)

## Details
These changes align the resource requests and limits more closely with the actual runtime requirements of the backup server application, allowing for better resource utilization in the Kubernetes cluster while maintaining adequate headroom for normal operations.

https://claude.ai/code/session_01PHcEFVjAzZXPXWz9QSs2kb