### PR TITLE
Use <bt-split-button> for the backup action

### DIFF
--- a/client/src/app/databases/databases.component.css
+++ b/client/src/app/databases/databases.component.css
@@ -5,7 +5,7 @@
   row-gap: 20px;
 }
 
-.backup-actions {
+bt-split-button {
   grid-column: 2;
   grid-row: 1;
   align-self: center;

--- a/client/src/app/databases/databases.component.css
+++ b/client/src/app/databases/databases.component.css
@@ -9,18 +9,6 @@
   grid-column: 2;
   grid-row: 1;
   align-self: center;
-  display: inline-flex;
-  align-items: center;
-}
-
-.backup-actions .backup-primary {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.backup-actions .backup-menu-trigger {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
 }
 
 h2 {

--- a/client/src/app/databases/databases.component.css
+++ b/client/src/app/databases/databases.component.css
@@ -1,20 +1,9 @@
 :host {
   display: grid;
   grid-template-columns: 1fr auto;
+  align-items: center;
   column-gap: 20px;
   row-gap: 20px;
-}
-
-bt-split-button {
-  grid-column: 2;
-  grid-row: 1;
-  align-self: center;
-}
-
-h2 {
-  grid-column: 1;
-  grid-row: 1;
-  align-self: center;
 }
 
 bt-bar-loader,

--- a/client/src/app/databases/databases.component.html
+++ b/client/src/app/databases/databases.component.html
@@ -2,7 +2,6 @@
 <bt-bar-loader />
 } @else {
 <bt-split-button
-  class="backup-actions"
   label="Backup"
   menuAriaLabel="More backup options"
   [disabled]="processing()"

--- a/client/src/app/databases/databases.component.html
+++ b/client/src/app/databases/databases.component.html
@@ -8,9 +8,7 @@
   [disabled]="processing()"
   (primaryAction)="backup()"
 >
-  <button mat-menu-item (click)="smartBackup()">
-    <span>Backup if needed</span>
-  </button>
+  <button mat-menu-item (click)="smartBackup()">Backup if needed</button>
 </bt-split-button>
 <h2 bt>
   Databases <span bt-badge>{{ databases.value()?.length }}</span>

--- a/client/src/app/databases/databases.component.html
+++ b/client/src/app/databases/databases.component.html
@@ -1,6 +1,9 @@
 @if (databases.isLoading()) {
 <bt-bar-loader />
 } @else {
+<h2 bt>
+  Databases <span bt-badge>{{ databases.value()?.length }}</span>
+</h2>
 <bt-split-button
   label="Backup"
   menuAriaLabel="More backup options"
@@ -9,9 +12,6 @@
 >
   <button mat-menu-item (click)="smartBackup()">Backup if needed</button>
 </bt-split-button>
-<h2 bt>
-  Databases <span bt-badge>{{ databases.value()?.length }}</span>
-</h2>
 @if (databases.value()?.length) {
 <table bt id="backups">
   <thead>

--- a/client/src/app/databases/databases.component.html
+++ b/client/src/app/databases/databases.component.html
@@ -1,30 +1,17 @@
 @if (databases.isLoading()) {
 <bt-bar-loader />
 } @else {
-<div class="backup-actions">
-  <button
-    mat-flat-button
-    color="primary"
-    class="backup-primary"
-    [disabled]="processing()"
-    (click)="backup()"
-  >
-    Backup
+<bt-split-button
+  class="backup-actions"
+  label="Backup"
+  menuAriaLabel="More backup options"
+  [disabled]="processing()"
+  (primaryAction)="backup()"
+>
+  <button mat-menu-item (click)="smartBackup()">
+    <span>Backup if needed</span>
   </button>
-  <button
-    mat-icon-button
-    color="primary"
-    class="backup-menu-trigger"
-    [disabled]="processing()"
-    [matMenuTriggerFor]="backupMenu"
-    aria-label="More backup options"
-  >
-    <mat-icon>arrow_drop_down</mat-icon>
-  </button>
-  <mat-menu #backupMenu="matMenu">
-    <button mat-menu-item (click)="smartBackup()">Backup if needed</button>
-  </mat-menu>
-</div>
+</bt-split-button>
 <h2 bt>
   Databases <span bt-badge>{{ databases.value()?.length }}</span>
 </h2>

--- a/client/src/app/databases/databases.component.ts
+++ b/client/src/app/databases/databases.component.ts
@@ -1,9 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { Router } from '@angular/router';
-import { BarLoaderComponent } from '@mucsi96/angular-material-theme';
+import {
+  BarLoaderComponent,
+  SplitButtonComponent,
+} from '@mucsi96/angular-material-theme';
 import { Database } from '../../types';
 import { olderThenOneDay } from '../utils/dateUtils';
 import { RelativeTimePipe } from '../utils/relativeTime.pipe';
@@ -14,10 +15,9 @@ import { DatabasesService } from './databases.service';
   standalone: true,
   imports: [
     RelativeTimePipe,
-    MatButtonModule,
-    MatIconModule,
     MatMenuModule,
     BarLoaderComponent,
+    SplitButtonComponent,
   ],
   templateUrl: './databases.component.html',
   styleUrl: './databases.component.css',

--- a/test/tests/test_databases.spec.ts
+++ b/test/tests/test_databases.spec.ts
@@ -43,7 +43,7 @@ test.describe('Databases Tests', () => {
     await page.goto('/');
     await expect(page.getByRole('row')).toHaveCount(3);
 
-    const tableData = await extractTableData(page.locator(':text("Databases") + table'));
+    const tableData = await extractTableData(page.locator(':text("Databases") ~ table'));
 
     expect(tableData).toEqual([
       {


### PR DESCRIPTION
Replace the hand-rolled mat-flat-button + mat-icon-button + mat-menu combo on the databases page with the theme package's split button so the primary action and the dropdown share a single, accessible component.

https://claude.ai/code/session_01MSCGuyAGrfZgxxgxXn5fsx