### PR TITLE
Upgrade @mucsi96/angular-material-theme to 1.3.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "21.2.12",
         "@angular/platform-browser-dynamic": "21.2.12",
         "@angular/router": "21.2.12",
-        "@mucsi96/angular-material-theme": "1.1.0",
+        "@mucsi96/angular-material-theme": "1.3.0",
         "@mucsi96/ui-elements": "69.0.0",
         "angular-auth-oidc-client": "^21.0.1",
         "rxjs": "7.8.2",
@@ -4362,9 +4362,9 @@
       ]
     },
     "node_modules/@mucsi96/angular-material-theme": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.1.0.tgz",
-      "integrity": "sha512-HfG5YrMeuNFsiL3Ee53cVuo8Q94hAYYUQHWTc7Ju2umKHSm/v9FuBKi5PpQtHkTagc/RR6DkIx+sxlD+fMPmFQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.3.0.tgz",
+      "integrity": "sha512-laT4qD4QoEBYYBHBCxV2esdfoRaFzemujOrJKWi7T+fqhVkJlMNYS43JCelZ6xFPoblhRPJdUFeWKxcnf4Q7Jw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "21.2.12",
     "@angular/router": "21.2.12",
     "angular-auth-oidc-client": "^21.0.1",
-    "@mucsi96/angular-material-theme": "1.1.0",
+    "@mucsi96/angular-material-theme": "1.3.0",
     "@mucsi96/ui-elements": "69.0.0",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",


### PR DESCRIPTION
## Summary
Updates the `@mucsi96/angular-material-theme` dependency from version 1.1.0 to 1.3.0 to incorporate the latest improvements and fixes from the theme library.

## Changes
- Bumped `@mucsi96/angular-material-theme` from 1.1.0 to 1.3.0 in client dependencies

## Notes
This is a minor version upgrade that should be backward compatible. The lockfile has been updated to reflect the transitive dependency changes.

https://claude.ai/code/session_015fzLJ9sFPXJK567b2pqLQh