### PR TITLE
Align header app-name link with skeleton pattern

### DIFF
--- a/client/src/app/app.component.css
+++ b/client/src/app/app.component.css
@@ -1,3 +1,7 @@
+a[mat-button] {
+  font-size: 16px;
+}
+
 main {
   margin-top: 32px;
 }

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -1,6 +1,6 @@
 <header bt>
   <nav>
-    <a routerLink="" bt-logo (click)="resetSelectedDatabase()"
+    <a routerLink="" mat-button (click)="resetSelectedDatabase()"
       >Postgres Backup Tool</a
     >
     @if(isAuthenticated()) {

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { AuthService } from './auth.service';
 import { SelectedDatabaseService } from './database/selected-database.service';
@@ -7,7 +8,7 @@ import { HeaderComponent } from './header/header.component';
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, RouterLink, HeaderComponent],
+  imports: [RouterOutlet, RouterLink, MatButtonModule, HeaderComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',
 })


### PR DESCRIPTION
Replace the `bt-logo` directive on the app title with `mat-button` and add the matching `a[mat-button] { font-size: 16px; }` rule from the skeleton-app diff.

https://claude.ai/code/session_01MrNQ2X954Nqq1JUu3aLrey