### PR TITLE
Add Twingate connection to CI/CD pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -211,6 +211,11 @@ jobs:
         with:
           kubelogin-version: 'v0.2.7'
 
+      - name: Connect to Twingate
+        uses: twingate/github-action@v1
+        with:
+          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+
       - name: Deploy to Kubernetes
         env:
           AZURE_KEYVAULT_NAME: ${{ secrets.AZURE_KEYVAULT_NAME }}


### PR DESCRIPTION
## Summary
This change adds Twingate network access to the GitHub Actions CI/CD pipeline, enabling secure connectivity to private resources during deployment.

## Changes
- Added Twingate GitHub Action step to the pipeline workflow
- Configured Twingate authentication using a service key secret
- Positioned the connection step before the Kubernetes deployment to ensure network access is established

## Implementation Details
The Twingate action is inserted in the deployment job after kubelogin setup and before the Kubernetes deployment step. This ensures that any private resources required during deployment (such as private Kubernetes clusters or internal registries) are accessible through the Twingate network.

The service key is securely passed via GitHub Secrets (`TWINGATE_SERVICE_KEY`), following security best practices for credential management in CI/CD pipelines.

https://claude.ai/code/session_01LzTdM6qLVkX6HUjYk6VuiW