### PR TITLE
Upgrade PostgreSQL from 17 to 18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,7 @@ Backup file representation:
 - **Docker** - Containerization
 - **Docker Compose** - Local orchestration
 - **Azurite** - Azure Blob Storage emulator
-- **PostgreSQL 17** - Database
+- **PostgreSQL 18** - Database
 - **Helm** - Kubernetes deployment
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Simple PostgreSQL backup tool to Azure with UI
 - Angular
 - OpenID Connect (`angular-auth-oidc-client`)
 - Azure
-- PostgreSQL 17 client
+- PostgreSQL 18 client
 - Podman (rootless containers + Kubernetes-style pod manifests)
 
 ## Local development

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -22,7 +22,7 @@ VOLUME /tmp
 ARG DEPENDENCY=/workspace/target/dependency
 ARG SPRING_PROFILES_ACTIVE=prod
 
-RUN apk add postgresql17-client curl
+RUN apk add postgresql18-client curl
 
 # Copy application layers
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib

--- a/test/test-pod.yaml
+++ b/test/test-pod.yaml
@@ -45,7 +45,7 @@ spec:
         failureThreshold: 30
 
     - name: db1
-      image: docker.io/library/postgres:17.5-bullseye
+      image: docker.io/library/postgres:18-trixie
       ports:
         - containerPort: 8164
           hostPort: 8164
@@ -66,7 +66,7 @@ spec:
         failureThreshold: 10
 
     - name: db2
-      image: docker.io/library/postgres:17.5-bullseye
+      image: docker.io/library/postgres:18-trixie
       ports:
         - containerPort: 8165
           hostPort: 8165

--- a/test/test-pod.yaml
+++ b/test/test-pod.yaml
@@ -45,7 +45,7 @@ spec:
         failureThreshold: 30
 
     - name: db1
-      image: docker.io/library/postgres:18-trixie
+      image: docker.io/library/postgres:18.4-trixie
       ports:
         - containerPort: 8164
           hostPort: 8164
@@ -66,7 +66,7 @@ spec:
         failureThreshold: 10
 
     - name: db2
-      image: docker.io/library/postgres:18-trixie
+      image: docker.io/library/postgres:18.4-trixie
       ports:
         - containerPort: 8165
           hostPort: 8165


### PR DESCRIPTION
## Summary
This PR upgrades PostgreSQL from version 17 to version 18 across the project, including test configurations, documentation, and Docker images.

## Key Changes
- Updated PostgreSQL image tags in test pod manifest from `17.5-bullseye` to `18.4-trixie` for both db1 and db2 containers (pinned to match the production server version, 18.4 / pgdg13)
- Updated PostgreSQL client package in server Dockerfile from `postgresql17-client` to `postgresql18-client`
- Updated documentation references to reflect PostgreSQL 18 as the supported version in AGENTS.md and README.md

## Implementation Details
- The pod manifest changes update both database containers to use the newer Debian Trixie base image alongside PostgreSQL 18
- The Dockerfile change ensures the application container has the correct PostgreSQL client tools for connecting to PostgreSQL 18 databases. This fixes the `pg_dump: error: aborting because of server version mismatch` failure that occurred when a 17.x `pg_dump` ran against the 18.4 production server.
- Documentation updates maintain consistency across all project references to the database version

https://claude.ai/code/session_0154XM9mM3Fr136YKw8C7NSe